### PR TITLE
feat: reduce disk size in order to have 2 disks within the same tier

### DIFF
--- a/modules/compute_engine.tf
+++ b/modules/compute_engine.tf
@@ -10,7 +10,7 @@ resource "google_compute_instance" "free_tier_vm" {
   boot_disk {
     initialize_params {
       image = "debian-cloud/debian-11"
-      size  = 30
+      size  = 12
       type  = "pd-standard"
     }
   }


### PR DESCRIPTION
From 30 to 12, in order to keep 2 disks (Dev and Prod) where sum is < 30GB.